### PR TITLE
PLT-30392 Add org level support for metadata document

### DIFF
--- a/Sustainsys.Saml2/WebSSO/MetadataCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/MetadataCommand.cs
@@ -33,7 +33,11 @@ namespace Sustainsys.Saml2.WebSso
 
             var urls = new Saml2Urls(request, options);
 
-			IdentityProvider identityProvider = options.Notifications.GetIdentityProvider(options.SPOptions.EntityId, null, options);
+            /* Dynamically fetch the identity provider for the entityid.
+             * This will ensure any settings controlled with a feature flag or dynamically refreshed values will be updated after Identity Server startup.
+             * We use these identity provider specific settings instead of the startup settings for the rest of the flow.
+             */
+            IdentityProvider identityProvider = options.Notifications.GetIdentityProvider(options.SPOptions.EntityId, null, options);
 
 			var metadata = identityProvider.spOptions.CreateMetadata(urls);
             options.Notifications.MetadataCreated(metadata, urls);
@@ -46,7 +50,7 @@ namespace Sustainsys.Saml2.WebSso
                 ContentType = "application/samlmetadata+xml"
             };
 
-            var fileName = CreateFileName(options.SPOptions.EntityId.Id);
+            var fileName = CreateFileName(identityProvider.spOptions.EntityId.Id);
 
             result.Headers.Add("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
 

--- a/Sustainsys.Saml2/WebSSO/MetadataCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/MetadataCommand.cs
@@ -33,14 +33,16 @@ namespace Sustainsys.Saml2.WebSso
 
             var urls = new Saml2Urls(request, options);
 
-            var metadata = options.SPOptions.CreateMetadata(urls);
+			IdentityProvider identityProvider = options.Notifications.GetIdentityProvider(options.SPOptions.EntityId, null, options);
+
+			var metadata = identityProvider.spOptions.CreateMetadata(urls);
             options.Notifications.MetadataCreated(metadata, urls);
 
             var result = new CommandResult()
             {
                 Content = metadata.ToXmlString(
-                    options.SPOptions.SigningServiceCertificate,
-                    options.SPOptions.OutboundSigningAlgorithm),
+					identityProvider.spOptions.SigningServiceCertificate,
+                    identityProvider.spOptions.OutboundSigningAlgorithm),
                 ContentType = "application/samlmetadata+xml"
             };
 


### PR DESCRIPTION
Currently, we setup the metadata document based on the host level configuration. Since we rotate our service certificate, we should build the metadata document based on the spOptions created for an incoming request rather than the spOptions configured during startup. 

Related Identity Server PR: https://github.com/UiPath/IdentityServer/pull/5103