### PR TITLE
PLT-48314 Enable SAML SLO Endpoint 

### DIFF
--- a/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
@@ -249,7 +249,7 @@ namespace Sustainsys.Saml2.WebSso
         {
             var request = Saml2LogoutRequest.FromXml(unbindResult.Data);
 
-            var idp = options.IdentityProviders[request.Issuer];
+            var idp = options.Notifications.GetIdentityProvider(request.Issuer, null, options);;
 
             if(options.SPOptions.SigningServiceCertificate == null)
             {

--- a/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
@@ -120,7 +120,7 @@ namespace Sustainsys.Saml2.WebSso
                 {
                     throw new InvalidSignatureException("There is no Issuer element in the message, so there is no way to know what certificate to use to validate the signature.");
                 }
-                var idp = options.IdentityProviders[new EntityId(issuer)];
+                var idp = options.Notifications.GetIdentityProvider(new EntityId(issuer), null, options);
 
                 if (!unbindResult.Data.IsSignedByAny(
                     idp.SigningKeys,
@@ -249,7 +249,7 @@ namespace Sustainsys.Saml2.WebSso
         {
             var request = Saml2LogoutRequest.FromXml(unbindResult.Data);
 
-            var idp = options.Notifications.GetIdentityProvider(request.Issuer, null, options);;
+            var idp = options.Notifications.GetIdentityProvider(request.Issuer, null, options);
 
             if(options.SPOptions.SigningServiceCertificate == null)
             {

--- a/Sustainsys.Saml2/WebSSO/MetadataCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/MetadataCommand.cs
@@ -26,7 +26,7 @@ namespace Sustainsys.Saml2.WebSso
         /// <returns>CommandResult</returns>
         public CommandResult Run(HttpRequestData request, IOptions options)
         {
-            if(options == null)
+            if (options == null)
             {
                 throw new ArgumentNullException(nameof(options));
             }

--- a/Sustainsys.Saml2/WebSSO/Saml2RedirectBinding.cs
+++ b/Sustainsys.Saml2/WebSSO/Saml2RedirectBinding.cs
@@ -131,7 +131,8 @@ namespace Sustainsys.Saml2.WebSso
                 return TrustLevel.None;
             }
 
-            if (!options.IdentityProviders.TryGetValue(new EntityId(issuer), out IdentityProvider idp))
+			IdentityProvider idp = options.Notifications.GetIdentityProvider(new EntityId(issuer), null, options);
+			if (idp == null)
             {
                 throw new InvalidSignatureException(string.Format(CultureInfo.InvariantCulture, "Cannot verify signature of message from unknown sender {0}.", issuer));
             }

--- a/Sustainsys.Saml2/WebSSO/Saml2RedirectBinding.cs
+++ b/Sustainsys.Saml2/WebSSO/Saml2RedirectBinding.cs
@@ -131,7 +131,7 @@ namespace Sustainsys.Saml2.WebSso
                 return TrustLevel.None;
             }
 
-			IdentityProvider idp = options.Notifications.GetIdentityProvider(new EntityId(issuer), null, options);
+		    IdentityProvider idp = options.Notifications.GetIdentityProvider(new EntityId(issuer), null, options);
 			if (idp == null)
             {
                 throw new InvalidSignatureException(string.Format(CultureInfo.InvariantCulture, "Cannot verify signature of message from unknown sender {0}.", issuer));


### PR DESCRIPTION
This PR adds support for the IdP initiated single log out flow in our SAML implementation. 

Related Identity PR: https://github.com/UiPath/IdentityServer/pull/7627

**Context**
IdP's provide the option to provide a single log out (SLO) URL when configuring the UiPath application. When a log out from the IdP is initiated, the IdP will trigger signouts for all of the applications that have a SLO URL configured. This URL will be opened in an iframe and will send a signed SAML log out request (example available here: https://www.identityserver.com/documentation/saml2p/protocol/examples/logout-request/). 

Once we, as the service provider, have performed the necessary steps to sign the user out, we redirect back to the SLO endpoint configured for the IdP (this endpoint is found in their metadata document). 
![image](https://github.com/UiPath/Saml2/assets/71667899/5917ffd9-d9b7-42df-89d2-4559e085353f)

**Purpose of PR**
In Identity, since we treat the Saml2ProviderService as a singleton, we load the host level identity providers during startup. This behavior is not compatible for our multi-org implementation. This PR changes logic to call the "GetIdentityProvider" notification, rather then reference the list of IdentityProviders configured during runtime. 

**Testing**
I have tested this implementation by configuring my local environment to AAD using SAML. Then, when triggering a sign out from AAD, I am able to witness my session be terminated and be redirected to the login screen.