### PR TITLE
PLT-50666 Update vulnerable dependencies

### DIFF
--- a/Sustainsys.Saml2.AspNetCore2/Sustainsys.Saml2.AspNetCore2.csproj
+++ b/Sustainsys.Saml2.AspNetCore2/Sustainsys.Saml2.AspNetCore2.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sustainsys.Saml2.AspNetCore2/Sustainsys.Saml2.AspNetCore2.csproj
+++ b/Sustainsys.Saml2.AspNetCore2/Sustainsys.Saml2.AspNetCore2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net47;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageReleaseNotes>$releaseNotes$</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Sustainsys.Saml2.sln
+++ b/Sustainsys.Saml2.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29613.14
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34607.119
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sustainsys.Saml2", "Sustainsys.Saml2\Sustainsys.Saml2.csproj", "{93BA675E-A159-4701-B68B-C4B81015C556}"
 EndProject
@@ -26,41 +26,17 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuget", "nuget", "{8EE1C45E
 		nuget\Sustainsys.Saml2.Owin.nuspec = nuget\Sustainsys.Saml2.Owin.nuspec
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sustainsys.Saml2.Mvc", "Sustainsys.Saml2.Mvc\Sustainsys.Saml2.Mvc.csproj", "{7D32F0A3-CEC8-4DC6-A096-5905EA9C3770}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sustainsys.Saml2.StubIdp", "Sustainsys.Saml2.StubIdp\Sustainsys.Saml2.StubIdp.csproj", "{7B60747D-6337-4424-ACB5-7D580EC1E1A1}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sustainsys.Saml2.Owin", "Sustainsys.Saml2.Owin\Sustainsys.Saml2.Owin.csproj", "{FA1E7723-124C-4D2D-A731-E16400B0073B}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sustainsys.Saml2.HttpModule", "Sustainsys.Saml2.HttpModule\Sustainsys.Saml2.HttpModule.csproj", "{86A588E8-2E2D-4394-9545-24D8EA939CF2}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{09639770-8C2B-4D30-BBFC-4F6DD1A92C89}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleHttpModuleApplication", "Samples\SampleHttpModuleApplication\SampleHttpModuleApplication.csproj", "{A8933B89-1052-43EF-A884-07860375F3FA}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleMvcApplication", "Samples\SampleMvcApplication\SampleMvcApplication.csproj", "{CE07482B-C6AB-4195-A1A7-3BB69176EFF2}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleOwinApplication", "Samples\SampleOwinApplication\SampleOwinApplication.csproj", "{1C263C1A-3201-4A90-96BB-22CD3F074EC8}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{F3C8CC66-4CE9-4683-BC31-B89AF47A5897}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mvc.Tests", "Tests\Mvc.Tests\Mvc.Tests.csproj", "{F09D61F6-CA41-4B73-B59E-2A5C5626F058}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestHelpers", "Tests\TestHelpers\TestHelpers.csproj", "{CF1E517E-B2FE-48E1-8BB9-4D9981695C47}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Owin.Tests", "Tests\Owin.Tests\Owin.Tests.csproj", "{0E01A985-54CC-4190-851F-6475C7BB1A5D}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HttpModule.Tests", "Tests\HttpModule.Tests\HttpModule.Tests.csproj", "{4D3EADFB-93E9-4F66-BD61-FBAC9E30A294}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAspNetCore2ApplicationNetFramework", "Samples\SampleAspNetCore2ApplicationNETFramework\SampleAspNetCore2ApplicationNetFramework.csproj", "{8EB3820A-4DB4-4875-A155-6C3D7458983E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sustainsys.Saml2.AspNetCore2", "Sustainsys.Saml2.AspNetCore2\Sustainsys.Saml2.AspNetCore2.csproj", "{0A1A7E8C-838C-4114-894B-564592417AFA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCore2.Tests", "Tests\AspNetCore2.Tests\AspNetCore2.Tests.csproj", "{20359A9A-6435-4264-8B36-22CD76731432}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests.NETCore", "Tests\Tests.NETCore\Tests.NETCore.csproj", "{FF774B2E-51D4-4C64-BA0E-C061683A9B93}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests.NETFramework", "Tests\Tests.NETFramework\Tests.NETFramework.csproj", "{C5C43D57-3A9C-4EDF-97AF-EE55A950284C}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Tests.Shared", "Tests\Tests.Shared\Tests.Shared.shproj", "{82F84E61-1292-47CF-B0DC-59F26EC56C32}"
 EndProject
@@ -97,14 +73,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "config-elements", "config-e
 		docs\config-elements\sustainsys-saml2.rst = docs\config-elements\sustainsys-saml2.rst
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleAesGcmNetCore31", "Samples\SampleAesGcmStartupNetCore31\SampleAesGcmNetCore31.csproj", "{309367E0-32C7-4916-9287-7C8CF7D626DF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAesGcmNetCore31", "Samples\SampleAesGcmStartupNetCore31\SampleAesGcmNetCore31.csproj", "{309367E0-32C7-4916-9287-7C8CF7D626DF}"
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		Tests\Tests.Shared\Tests.Shared.projitems*{82f84e61-1292-47cf-b0dc-59f26ec56c32}*SharedItemsImports = 13
-		Tests\Tests.Shared\Tests.Shared.projitems*{c5c43d57-3a9c-4edf-97af-ee55a950284c}*SharedItemsImports = 4
-		Tests\Tests.Shared\Tests.Shared.projitems*{ff774b2e-51d4-4c64-ba0e-c061683a9b93}*SharedItemsImports = 5
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -114,54 +85,10 @@ Global
 		{93BA675E-A159-4701-B68B-C4B81015C556}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{93BA675E-A159-4701-B68B-C4B81015C556}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{93BA675E-A159-4701-B68B-C4B81015C556}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7D32F0A3-CEC8-4DC6-A096-5905EA9C3770}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7D32F0A3-CEC8-4DC6-A096-5905EA9C3770}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7D32F0A3-CEC8-4DC6-A096-5905EA9C3770}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7D32F0A3-CEC8-4DC6-A096-5905EA9C3770}.Release|Any CPU.Build.0 = Release|Any CPU
-		{7B60747D-6337-4424-ACB5-7D580EC1E1A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7B60747D-6337-4424-ACB5-7D580EC1E1A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7B60747D-6337-4424-ACB5-7D580EC1E1A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7B60747D-6337-4424-ACB5-7D580EC1E1A1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{FA1E7723-124C-4D2D-A731-E16400B0073B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FA1E7723-124C-4D2D-A731-E16400B0073B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{FA1E7723-124C-4D2D-A731-E16400B0073B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{FA1E7723-124C-4D2D-A731-E16400B0073B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{86A588E8-2E2D-4394-9545-24D8EA939CF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{86A588E8-2E2D-4394-9545-24D8EA939CF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{86A588E8-2E2D-4394-9545-24D8EA939CF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{86A588E8-2E2D-4394-9545-24D8EA939CF2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A8933B89-1052-43EF-A884-07860375F3FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A8933B89-1052-43EF-A884-07860375F3FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A8933B89-1052-43EF-A884-07860375F3FA}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{A8933B89-1052-43EF-A884-07860375F3FA}.Release|Any CPU.Build.0 = Debug|Any CPU
-		{CE07482B-C6AB-4195-A1A7-3BB69176EFF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CE07482B-C6AB-4195-A1A7-3BB69176EFF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CE07482B-C6AB-4195-A1A7-3BB69176EFF2}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{CE07482B-C6AB-4195-A1A7-3BB69176EFF2}.Release|Any CPU.Build.0 = Debug|Any CPU
-		{1C263C1A-3201-4A90-96BB-22CD3F074EC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1C263C1A-3201-4A90-96BB-22CD3F074EC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1C263C1A-3201-4A90-96BB-22CD3F074EC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1C263C1A-3201-4A90-96BB-22CD3F074EC8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F09D61F6-CA41-4B73-B59E-2A5C5626F058}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F09D61F6-CA41-4B73-B59E-2A5C5626F058}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F09D61F6-CA41-4B73-B59E-2A5C5626F058}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F09D61F6-CA41-4B73-B59E-2A5C5626F058}.Release|Any CPU.Build.0 = Release|Any CPU
 		{CF1E517E-B2FE-48E1-8BB9-4D9981695C47}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CF1E517E-B2FE-48E1-8BB9-4D9981695C47}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CF1E517E-B2FE-48E1-8BB9-4D9981695C47}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CF1E517E-B2FE-48E1-8BB9-4D9981695C47}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0E01A985-54CC-4190-851F-6475C7BB1A5D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0E01A985-54CC-4190-851F-6475C7BB1A5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0E01A985-54CC-4190-851F-6475C7BB1A5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0E01A985-54CC-4190-851F-6475C7BB1A5D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{4D3EADFB-93E9-4F66-BD61-FBAC9E30A294}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4D3EADFB-93E9-4F66-BD61-FBAC9E30A294}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4D3EADFB-93E9-4F66-BD61-FBAC9E30A294}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4D3EADFB-93E9-4F66-BD61-FBAC9E30A294}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8EB3820A-4DB4-4875-A155-6C3D7458983E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8EB3820A-4DB4-4875-A155-6C3D7458983E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8EB3820A-4DB4-4875-A155-6C3D7458983E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8EB3820A-4DB4-4875-A155-6C3D7458983E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0A1A7E8C-838C-4114-894B-564592417AFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0A1A7E8C-838C-4114-894B-564592417AFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0A1A7E8C-838C-4114-894B-564592417AFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -174,10 +101,6 @@ Global
 		{FF774B2E-51D4-4C64-BA0E-C061683A9B93}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF774B2E-51D4-4C64-BA0E-C061683A9B93}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FF774B2E-51D4-4C64-BA0E-C061683A9B93}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C5C43D57-3A9C-4EDF-97AF-EE55A950284C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C5C43D57-3A9C-4EDF-97AF-EE55A950284C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C5C43D57-3A9C-4EDF-97AF-EE55A950284C}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{C5C43D57-3A9C-4EDF-97AF-EE55A950284C}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{19ED65C5-A184-4AA8-9CBB-464E7433075A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{19ED65C5-A184-4AA8-9CBB-464E7433075A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19ED65C5-A184-4AA8-9CBB-464E7433075A}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -195,17 +118,9 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{A8933B89-1052-43EF-A884-07860375F3FA} = {09639770-8C2B-4D30-BBFC-4F6DD1A92C89}
-		{CE07482B-C6AB-4195-A1A7-3BB69176EFF2} = {09639770-8C2B-4D30-BBFC-4F6DD1A92C89}
-		{1C263C1A-3201-4A90-96BB-22CD3F074EC8} = {09639770-8C2B-4D30-BBFC-4F6DD1A92C89}
-		{F09D61F6-CA41-4B73-B59E-2A5C5626F058} = {F3C8CC66-4CE9-4683-BC31-B89AF47A5897}
 		{CF1E517E-B2FE-48E1-8BB9-4D9981695C47} = {F3C8CC66-4CE9-4683-BC31-B89AF47A5897}
-		{0E01A985-54CC-4190-851F-6475C7BB1A5D} = {F3C8CC66-4CE9-4683-BC31-B89AF47A5897}
-		{4D3EADFB-93E9-4F66-BD61-FBAC9E30A294} = {F3C8CC66-4CE9-4683-BC31-B89AF47A5897}
-		{8EB3820A-4DB4-4875-A155-6C3D7458983E} = {09639770-8C2B-4D30-BBFC-4F6DD1A92C89}
 		{20359A9A-6435-4264-8B36-22CD76731432} = {F3C8CC66-4CE9-4683-BC31-B89AF47A5897}
 		{FF774B2E-51D4-4C64-BA0E-C061683A9B93} = {F3C8CC66-4CE9-4683-BC31-B89AF47A5897}
-		{C5C43D57-3A9C-4EDF-97AF-EE55A950284C} = {F3C8CC66-4CE9-4683-BC31-B89AF47A5897}
 		{82F84E61-1292-47CF-B0DC-59F26EC56C32} = {F3C8CC66-4CE9-4683-BC31-B89AF47A5897}
 		{19ED65C5-A184-4AA8-9CBB-464E7433075A} = {09639770-8C2B-4D30-BBFC-4F6DD1A92C89}
 		{A6DA495F-3AE8-482B-BC63-1F70BC752654} = {09639770-8C2B-4D30-BBFC-4F6DD1A92C89}
@@ -214,5 +129,9 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A8812E38-A212-46DD-B51F-AB653F39E4ED}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Tests\Tests.Shared\Tests.Shared.projitems*{82f84e61-1292-47cf-b0dc-59f26ec56c32}*SharedItemsImports = 13
+		Tests\Tests.Shared\Tests.Shared.projitems*{ff774b2e-51d4-4c64-ba0e-c061683a9b93}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/Sustainsys.Saml2/Sustainsys.Saml2.csproj
+++ b/Sustainsys.Saml2/Sustainsys.Saml2.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net47;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageReleaseNotes>$releaseNotes$</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Sustainsys.Saml2/Sustainsys.Saml2.csproj
+++ b/Sustainsys.Saml2/Sustainsys.Saml2.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.2.4" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens.Saml" Version="5.2.4" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.1" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.5.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.1" />
   </ItemGroup>
 
   </Project>

--- a/Sustainsys.Saml2/WebSSO/MetadataCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/MetadataCommand.cs
@@ -37,20 +37,28 @@ namespace Sustainsys.Saml2.WebSso
              * This will ensure any settings controlled with a feature flag or dynamically refreshed values will be updated after Identity Server startup.
              * We use these identity provider specific settings instead of the startup settings for the rest of the flow.
              */
-            IdentityProvider identityProvider = options.Notifications.GetIdentityProvider(options.SPOptions.EntityId, null, options);
+            SPOptions spOptions = null;
+            if (options.IdentityProviders != null && options.IdentityProviders.TryGetValue(options.SPOptions.EntityId, out var identityProvider))
+            {
+                spOptions = identityProvider.spOptions;
+            }
+            else
+            {
+                spOptions = options.SPOptions;
+            }
 
-			var metadata = identityProvider.spOptions.CreateMetadata(urls);
+			var metadata = spOptions.CreateMetadata(urls);
             options.Notifications.MetadataCreated(metadata, urls);
 
             var result = new CommandResult()
             {
                 Content = metadata.ToXmlString(
-					identityProvider.spOptions.SigningServiceCertificate,
-                    identityProvider.spOptions.OutboundSigningAlgorithm),
+					spOptions.SigningServiceCertificate,
+                    spOptions.OutboundSigningAlgorithm),
                 ContentType = "application/samlmetadata+xml"
             };
 
-            var fileName = CreateFileName(identityProvider.spOptions.EntityId.Id);
+            var fileName = CreateFileName(spOptions.EntityId.Id);
 
             result.Headers.Add("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
 

--- a/Sustainsys.Saml2/WebSSO/Saml2RedirectBinding.cs
+++ b/Sustainsys.Saml2/WebSSO/Saml2RedirectBinding.cs
@@ -131,8 +131,7 @@ namespace Sustainsys.Saml2.WebSso
                 return TrustLevel.None;
             }
 
-		    IdentityProvider idp = options.Notifications.GetIdentityProvider(new EntityId(issuer), null, options);
-			if (idp == null)
+            if (!options.IdentityProviders.TryGetValue(new EntityId(issuer), out IdentityProvider idp) || idp == null)
             {
                 throw new InvalidSignatureException(string.Format(CultureInfo.InvariantCulture, "Cannot verify signature of message from unknown sender {0}.", issuer));
             }

--- a/Tests/AspNetCore2.Tests/AspNetCore2.Tests.csproj
+++ b/Tests/AspNetCore2.Tests/AspNetCore2.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Tests.NETCore/Tests.NETCore.csproj
+++ b/Tests/Tests.NETCore/Tests.NETCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />

--- a/Tests/Tests.Shared/IdentityProviderTests.cs
+++ b/Tests/Tests.Shared/IdentityProviderTests.cs
@@ -969,7 +969,7 @@ namespace Sustainsys.Saml2.Tests
 
             subject.Invoking(s => s.CreateLogoutRequest(user))
                 .Should().Throw<ArgumentNullException>()
-                .And.Message.Should().Be("Value cannot be null.\r\nParameter name: user");
+                .And.Message.Should().Be("Value cannot be null. (Parameter 'user')");
         }
 
         [TestMethod]


### PR DESCRIPTION
[PLT-50666](https://uipath.atlassian.net/browse/PLT-50666)

Our fork of Sustainsys also includes the .NET Framework projects and NuGet packages. These are not needed in UiPath. The test projects were targeting .NET Core 2.1 and 3.1, which are both out of support, so those are updated to .NET 6.

This also fixes a regression introduced in #3 where a KeyNotFoundException would be thrown when trying to find an identity provider not in the options, which the test cases use in several places.

[PLT-50666]: https://uipath.atlassian.net/browse/PLT-50666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ