### PR TITLE
SRE-190858 Fix for invalid entity ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ docs/_build
 docs/.vscode
 /opencovertests.xml
 /GeneratedReports
+/nuget/nuget.exe

--- a/Tests/Tests.NETCore/Tests.NETCore.csproj
+++ b/Tests/Tests.NETCore/Tests.NETCore.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NETCOREAPP2_1</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Tests.Shared/Helpers/StubServer.cs
+++ b/Tests/Tests.Shared/Helpers/StubServer.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP2_1
+﻿#if NET6_0_OR_GREATER
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Hosting;
@@ -25,8 +25,8 @@ namespace Sustainsys.Saml2.Tests.Helpers
 {
     public class StubServer
     {
-#if NETCOREAPP2_1
-		private static IWebHost host;
+#if NET6_0_OR_GREATER
+        private static IWebHost host;
 #else
         private static IDisposable host;
 #endif
@@ -384,8 +384,8 @@ entityID=""http://localhost:13428/idpMetadataVeryShortCacheDuration"" cacheDurat
 			await next.Invoke();
 		}
 
-#if NETCOREAPP2_1
-		public static void Start()
+#if NET6_0_OR_GREATER
+        public static void Start()
         {
 			host = new WebHostBuilder()
 				.UseUrls("http://localhost:13428")


### PR DESCRIPTION
[SRE-190858](https://uipath.atlassian.net/browse/SRE-190858)

With #3 we started loading the SPOptions from the IdentityProviders list based on the entity ID. However, it appears that the entity ID used for the key to the IdentityProviders dictionary is not the same as the entity ID used in the SPOptions value. This has resulted in the entityID field in SAML metadata showing up as the host-level Identity URL and not the organization-specific URL. This fix is to lock the entity ID to the one passed in but still use the rest of the fields from the dynamically-loaded SPOptions.

[SRE-190858]: https://uipath.atlassian.net/browse/SRE-190858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ