### PR TITLE
PLT-89977 Modify Logout Command to use information from idp

### DIFF
--- a/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
+++ b/Sustainsys.Saml2/WebSSO/LogOutCommand.cs
@@ -251,7 +251,7 @@ namespace Sustainsys.Saml2.WebSso
 
             var idp = options.Notifications.GetIdentityProvider(request.Issuer, null, options);
 
-            if(options.SPOptions.SigningServiceCertificate == null)
+            if(idp.spOptions.SigningServiceCertificate == null)
             {
                 throw new ConfigurationErrorsException(string.Format(CultureInfo.InvariantCulture,
                     "Received a LogoutRequest from \"{0}\" but cannot reply because single logout responses " +
@@ -272,10 +272,10 @@ namespace Sustainsys.Saml2.WebSso
             var response = new Saml2LogoutResponse(Saml2StatusCode.Success)
             {
                 DestinationUrl = idp.SingleLogoutServiceResponseUrl,
-                SigningCertificate = options.SPOptions.SigningServiceCertificate,
+                SigningCertificate = idp.spOptions.SigningServiceCertificate,
                 SigningAlgorithm = idp.OutboundSigningAlgorithm,
                 InResponseTo = request.Id,
-                Issuer = options.SPOptions.EntityId,
+                Issuer = idp.spOptions.EntityId,
                 RelayState = unbindResult.RelayState
             };
 

--- a/Tests/Tests.Shared/WebSSO/LogoutCommandTests.cs
+++ b/Tests/Tests.Shared/WebSSO/LogoutCommandTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using Sustainsys.Saml2;
 using Sustainsys.Saml2.Configuration;
 using Sustainsys.Saml2.Exceptions;
 using Sustainsys.Saml2.Metadata;
@@ -19,6 +20,7 @@ using System.Text;
 using System.Threading;
 using System.Web;
 using Microsoft.IdentityModel.Tokens.Saml2;
+using NSubstitute;
 
 namespace Sustainsys.Saml2.Tests.WebSso
 {
@@ -1142,5 +1144,123 @@ namespace Sustainsys.Saml2.Tests.WebSso
 
             a.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("options");
         }
+
+        [TestMethod]
+        public void LogoutCommand_HandleRequest_UsesIdpSpecificSPOptions_ForMultiTenancy()
+        {
+            // Arrange - Create two different SP options for multi-tenancy scenario
+            var globalSpOptions = StubFactory.CreateSPOptions();
+            globalSpOptions.EntityId = new EntityId("https://global-sp.example.com");
+            globalSpOptions.ServiceCertificates.Add(SignedXmlHelper.TestCert);
+
+            var tenantSpecificSpOptions = StubFactory.CreateSPOptions();
+            tenantSpecificSpOptions.EntityId = new EntityId("https://tenant-specific-sp.example.com");
+            tenantSpecificSpOptions.ServiceCertificates.Add(SignedXmlHelper.TestCert2);
+
+            var options = new Options(globalSpOptions);
+
+            // Create an IDP with tenant-specific SP options
+            var idp = new IdentityProvider(new EntityId("https://idp.example.com"), tenantSpecificSpOptions);
+            idp.SingleLogoutServiceUrl = new Uri("https://idp.example.com/logout");
+            idp.Binding = Saml2BindingType.HttpRedirect; // Fix: Set the binding explicitly
+            idp.SigningKeys.AddConfiguredKey(SignedXmlHelper.TestCert);
+
+            options.IdentityProviders.Add(idp);
+
+            // Create a logout request from the IDP
+            var request = new Saml2LogoutRequest()
+            {
+                DestinationUrl = new Uri("http://sp.example.com/path/Saml2/logout"),
+                Issuer = new EntityId("https://idp.example.com"),
+                SigningCertificate = SignedXmlHelper.TestCert,
+                NameId = new Saml2NameIdentifier("NameId"),
+                SessionIndex = "SessionID",
+                SigningAlgorithm = SecurityAlgorithms.RsaSha256Signature
+            };
+
+            var bindResult = Saml2Binding.Get(Saml2BindingType.HttpRedirect).Bind(request);
+
+            var httpRequest = new HttpRequestData(
+                "GET",
+                bindResult.Location,
+                "/",
+                null,
+                cookieName => null,
+                null,
+                new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim(Saml2ClaimTypes.SessionIndex, "SessionID") })));
+
+            Saml2LogoutResponse logoutResponse = null;
+            options.Notifications.LogoutResponseCreated = (resp, req, u, receivedIdp) =>
+            {
+                logoutResponse = resp;
+                // Verify that the response uses tenant-specific SP options
+                resp.Issuer.Id.Should().Be("https://tenant-specific-sp.example.com", 
+                    "Response should use tenant-specific EntityId, not global one");
+                resp.SigningCertificate.Thumbprint.Should().Be(SignedXmlHelper.TestCert2.Thumbprint,
+                    "Response should use tenant-specific certificate, not global one");
+            };
+
+            // Act
+            var actual = CommandFactory.GetCommand(CommandFactory.LogoutCommandName)
+                .Run(httpRequest, options);
+
+            // Assert
+            actual.Should().NotBeNull();
+            logoutResponse.Should().NotBeNull();
+            logoutResponse.Issuer.Id.Should().Be("https://tenant-specific-sp.example.com");
+            logoutResponse.SigningCertificate.Thumbprint.Should().Be(SignedXmlHelper.TestCert2.Thumbprint);
+        }
+
+        [TestMethod]
+        public void LogoutCommand_HandleRequest_ThrowsWhenTenantSpecificCertificateIsNull()
+        {
+            // Arrange - Create tenant-specific SP options without certificate
+            var globalSpOptions = StubFactory.CreateSPOptions();
+            globalSpOptions.EntityId = new EntityId("https://global-sp.example.com");
+            globalSpOptions.ServiceCertificates.Add(SignedXmlHelper.TestCert);
+
+            var tenantSpecificSpOptions = StubFactory.CreateSPOptions();
+            tenantSpecificSpOptions.EntityId = new EntityId("https://tenant-specific-sp.example.com");
+            // Intentionally not adding any certificate for this tenant
+
+            var options = new Options(globalSpOptions);
+
+            var idp = new IdentityProvider(new EntityId("https://idp.example.com"), tenantSpecificSpOptions);
+            idp.SingleLogoutServiceUrl = new Uri("https://idp.example.com/logout");
+            idp.Binding = Saml2BindingType.HttpRedirect; // Fix: Set the binding explicitly
+            idp.SigningKeys.AddConfiguredKey(SignedXmlHelper.TestCert);
+
+            options.IdentityProviders.Add(idp);
+
+            var request = new Saml2LogoutRequest()
+            {
+                DestinationUrl = new Uri("http://sp.example.com/path/Saml2/logout"),
+                Issuer = new EntityId("https://idp.example.com"),
+                SigningCertificate = SignedXmlHelper.TestCert,
+                NameId = new Saml2NameIdentifier("NameId"),
+                SessionIndex = "SessionID",
+                SigningAlgorithm = SecurityAlgorithms.RsaSha256Signature
+            };
+
+            var bindResult = Saml2Binding.Get(Saml2BindingType.HttpRedirect).Bind(request);
+
+            var httpRequest = new HttpRequestData(
+                "GET",
+                bindResult.Location,
+                "/",
+                null,
+                cookieName => null,
+                null,
+                new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim(Saml2ClaimTypes.SessionIndex, "SessionID") })));
+
+            // Act & Assert
+            var command = CommandFactory.GetCommand(CommandFactory.LogoutCommandName);
+            Action act = () => command.Run(httpRequest, options);
+
+            act.Should().Throw<ConfigurationErrorsException>()
+                .WithMessage("*single logout responses must be signed and there is no signing certificate configured*");
+        }
+
+
     }
 }


### PR DESCRIPTION
**Description**
The SLO logout flow is currently failing due to a service provider signing certificate not being populated.
<img width="1684" height="864" alt="image" src="https://github.com/user-attachments/assets/ffb76740-b89e-4dae-9650-b342277cac7c" />
Historically, the setting used `options.SPOptions` which was only populated during startup here: https://github.com/UiPath/IdentityServer/blob/2c6b2f5348bcef6f26e3b93a3f18aff5b62c7cfb/src/Authentication.Saml2/Saml2ProviderService.cs#L153

This initially loaded our static certificate, then our token signing certificates, and [after this change](https://github.com/UiPath/IdentityServer/blob/4e1a4b4ea799345fc4296d8fece26eac02994aca/src/Authentication.Saml2/Saml2ProviderService.cs#L557), there are no certificates configured at the host level in cloud. Before that change, the SLO flow worked because we used the host level certificates to sign the response. 

This PR modifies the logout flow to use the service certificates that are specific to the identity provider (we provide customers the option to choose which certificate they would like us to use and fallback to our token signing certificate if they dont provide any). 

**Testing**
Unit tests are passing: <img width="1072" height="434" alt="image" src="https://github.com/user-attachments/assets/f63c4381-1f44-4a58-98a2-bc59177bf2cf" />

When debugging locally, there is an unrelated bug in our local development environment where the logout is failing. However, I was able to see the logout call being triggered by this line: https://github.com/UiPath/Saml2/blob/dc2d8ea9612c21f32f62d3f99099f2fa051bb8dd/Sustainsys.Saml2.AspNetCore2/CommandResultExtensions.cs#L84

Additionally, I have uploaded a custom version of my nuget package here: https://uipath.visualstudio.com/Identity/_artifacts/feed/nuget-packages/NuGet/UiPath.Swapnil.Sustainsys.Saml2.AspNetCore2/overview/1.0.11.1. I'll use this version to test in an ETE environment before merging. After merging I'll generate a new version and update the version in identity like the following: https://github.com/UiPath/IdentityServer/pull/10739


------------------------------

For future reference, I used the following commands after changing the project settings
1. Make sure CsProj has this section
```
<PropertyGroup>
  <PackageId>MyLibrary</PackageId>
  <Version>1.0.0</Version>
  <Authors>YourName</Authors>
  <Company>YourCompany</Company>
  <Description>Short description of your package</Description>
</PropertyGroup>
```

2. Navigate to the project folder and run `dotnet pack --configuration Release`. This will create the nupkg file in the bin/Release folder.

3. Download nuget.exe [here](https://learn.microsoft.com/en-us/nuget/install-nuget-client-tools?tabs=windows#install-nugetexe) and run 
`nuget.exe push UiPath.Swapnil.Sustainsys.Saml2.AspNetCore2.1.0.11.1.nupkg -Source nuget-packages -ApiKey VSTS`